### PR TITLE
fix:调用通知报错

### DIFF
--- a/ql.js
+++ b/ql.js
@@ -9,7 +9,7 @@ const qlDir = '/ql';
 const authFile = path.join(qlDir, 'config/auth.json');
 
 const api = got.extend({
-  prefixUrl: 'http://localhost:5600',
+  prefixUrl: 'http://127.0.0.1:5600',
   retry: { limit: 0 },
 });
 


### PR DESCRIPTION
#45 
解决发送通知时，调用ql.js后` RequestError: getaddrinfo ENOTFOUND localhost `报错问题。