### PR TITLE
兼容青龙v2.12.0

### DIFF
--- a/ql.js
+++ b/ql.js
@@ -6,7 +6,7 @@ const { readFile } = require('fs/promises');
 const path = require('path');
 
 const qlDir = '/ql';
-const authFile = path.join(qlDir, 'config/auth.json');
+const authFile = path.join(qlDir, 'data/config/auth.json');
 
 const api = got.extend({
   prefixUrl: 'http://127.0.0.1:5600',


### PR DESCRIPTION
青龙v2.12.0调整了数据目录，log、db、scripts、config等目录迁移到 /ql/data 目录