### PR TITLE
过期通知添加摘要

### DIFF
--- a/sendNotify.js
+++ b/sendNotify.js
@@ -365,25 +365,26 @@ async function sendNotify(text, desp, params = {}, author = '\n\n本通知 By cc
 
                                 if (DisableCkBody.code == 200) {
                                     console.log(`京东账号` + strdecPtPin + `已失效,自动禁用成功!\n`);
-
+                                    strsummary = `京东账号` + strdecPtPin + `已失效,自动禁用成功`;
                                     strNotifyOneTemp = `京东账号: ` + strdecPtPin + ` 已失效,自动禁用成功!\n如果要继续挂机，请联系管理员重新登录账号，账号有效期为30天.`;
                                     strNotifyOneTemp += "\n任务标题：" + strtext;
                                     if (strAllNotify)
                                         strNotifyOneTemp += `\n` + strAllNotify;
                                     desp = strNotifyOneTemp;
                                     if (WP_APP_TOKEN_ONE) {
-                                        await sendNotifybyWxPucher(`账号过期下线通知`, strNotifyOneTemp, strdecPtPin);
+                                        await sendNotifybyWxPucher(`账号过期下线通知`, strNotifyOneTemp, strdecPtPin, strsummary);
                                     }
 
                                 } else {
                                     console.log(`京东账号` + strPtPin + `已失效,自动禁用失败!\n`);
+                                    strsummary = `京东账号` + strdecPtPin + `已失效,自动禁用失败`;
                                     strNotifyOneTemp = `京东账号: ` + strdecPtPin + ` 已失效!\n如果要继续挂机，请联系管理员重新登录账号，账号有效期为30天.`;
                                     strNotifyOneTemp += "\n任务标题：" + strtext;
                                     if (strAllNotify)
                                         strNotifyOneTemp += `\n` + strAllNotify;
                                     desp = strNotifyOneTemp;
                                     if (WP_APP_TOKEN_ONE) {
-                                        await sendNotifybyWxPucher(`账号过期下线通知`, strNotifyOneTemp, strdecPtPin);
+                                        await sendNotifybyWxPucher(`账号过期下线通知`, strNotifyOneTemp, strdecPtPin, strsummary);
                                     }
                                 }
                             } else {


### PR DESCRIPTION
过期通知没有摘要，会导致wxpush的卡片通知显示为html代码，必须点击后才能查看是什么通知
![Screenshot_2023-07-11-14-17-39-518_com tencent mm](https://github.com/ccwav/QLScript2/assets/19207540/26bfd7eb-05c6-4757-aaf4-0a867b87c31e)
